### PR TITLE
Add jshint functionality + some code cleanup

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+node_modules
+webroot/jquery*
+webroot/soundjs*

--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,7 @@
   "boss"          : false,
   "browser"	  : true,
   "curly"         : true,
-  "eqeqeq"        : false,
+  "eqeqeq"        : true,
   "eqnull"        : false,
   "evil"          : false,
   "expr"          : false,
@@ -25,7 +25,7 @@
   "sub"           : true,
   "undef"         : true,
   "white"         : true,
-  "-W041"         : false, // this suppresses the warning "Use '===' to compare with '0'."
+//  "-W041"         : false, // this suppresses the warning "Use '===' to compare with '0'."
 
   "globals": { // global variables from node modules and jquery etc that jshint needs to know about. false means readonly, true means r/w
               "$"              : false,

--- a/.jshintrc
+++ b/.jshintrc
@@ -25,9 +25,8 @@
   "sub"           : true,
   "undef"         : true,
   "white"         : true,
-//  "-W041"         : false, // this suppresses the warning "Use '===' to compare with '0'."
 
-  "globals": { // global variables from node modules and jquery etc that jshint needs to know about. false means readonly, true means r/w
+  "globals": { /* global variables from node modules and jquery etc that jshint needs to know about. false means readonly, true means r/w */
               "$"              : false,
               "io"             : false,
               "clientSettings" : false,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,37 @@
+{
+  "asi"           : true,
+  "laxbreak"      : true,
+  "bitwise"       : true,
+  "boss"          : false,
+  "browser"	  : true,
+  "curly"         : true,
+  "eqeqeq"        : false,
+  "eqnull"        : false,
+  "evil"          : false,
+  "expr"          : false,
+  "forin"         : false,
+  "immed"         : true,
+  "indent"        : 2,
+  "latedef"       : true,
+  "loopfunc"      : false,
+  "noarg"         : true,
+  "node"          : true,
+  "regexp"        : true,
+  "regexdash"     : false,
+  "strict"        : false,
+  "scripturl"     : true,
+  "shadow"        : false,
+  "supernew"      : false,
+  "sub"           : true,
+  "undef"         : true,
+  "white"         : true,
+  "-W041"         : false, // this suppresses the warning "Use '===' to compare with '0'."
+
+  "globals": { // global variables from node modules and jquery etc that jshint needs to know about. false means readonly, true means r/w
+              "$"              : false,
+              "io"             : false,
+              "clientSettings" : false,
+              "createjs"       : false,
+              "preload"        : false
+  } 
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Soundbread NodeJS",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "jshint": "jshint -c .jshintrc --exclude-path .jshintignore ."
   },
+  "pre-commit": "jshint",
+
   "repository": {
     "type": "git",
     "url": "https://github.com/SoundBread/soundbread-nodejs"
@@ -19,5 +22,9 @@
     "express": "^4.13.4",
     "socket.io": "^1.4.6",
     "ws": "^1.1.0"
+  },
+  "devDependencies": {
+    "jshint": "~2.9.2",
+    "pre-commit": "~1.1.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -27,11 +27,11 @@ app.use('/settings.js', function(req, res, next) {
 app.use(express.static(__dirname + '/webroot'))
 
 // Clients
-var clients = new Object();
+var clients = {};
 clients.size = function(){
 	var size = 0, key;
 	for (key in clients) {
-			if (clients.hasOwnProperty(key)) size++;
+		if (clients.hasOwnProperty(key)) { size++; }
 	}
 	return size-1;
 }

--- a/settings.default.js
+++ b/settings.default.js
@@ -3,11 +3,11 @@ var clientSettings = {
 }
 
 var loc = window.location.href+'';
-if (loc.indexOf('http://') == 0) {
+if (loc.indexOf('http://') === 0) {
 	window.location.href = loc.replace('http://','https://');
 }
 
-if(location.protocol == 'https:') {
+if(location.protocol === 'https:') {
 	clientSettings.wsuri = 'wss://' + location.host
 } else {
 	clientSettings.wsuri = 'ws://' + location.host

--- a/settings.local.js
+++ b/settings.local.js
@@ -2,7 +2,7 @@ var clientSettings = {
 	wsuri: 'ws://localhost/'
 }
 
-if(location.protocol == 'https:') {
+if(location.protocol === 'https:') {
 	clientSettings.wsuri = 'wss://' + location.host
 } else {
 	clientSettings.wsuri = 'ws://' + location.host

--- a/settings.openshift.js
+++ b/settings.openshift.js
@@ -2,7 +2,7 @@ var clientSettings = {
 	wsuri: 'ws://localhost/'
 }
 
-if(location.protocol == 'https:') {
+if(location.protocol === 'https:') {
 	clientSettings.wsuri = 'wss://' + location.hostname + ':8443'
 } else {
 	clientSettings.wsuri = 'ws://' + location.hostname + ':8000'

--- a/webroot/soundbread.js
+++ b/webroot/soundbread.js
@@ -5,7 +5,7 @@ function soundLoaded(event) {
 }
 
 function stop() {
-  if (preload != null) {
+  if (preload !== null) {
     preload.close();
   }
   createjs.Sound.stop();
@@ -15,7 +15,7 @@ function play(id) {
   //Play the sound: play (src, interrupt, delay, offset, loop, volume, pan)
   console.log('play: ' + id);
   var instance = createjs.Sound.play(id);
-  if (instance == null || instance.playState == createjs.Sound.PLAY_FAILED) {
+  if (instance === null || instance.playState === createjs.Sound.PLAY_FAILED) {
     console.log('Play failed');
     return;
   }
@@ -82,9 +82,9 @@ function init()
   $(document).keydown(function(e){
     keyCode = '' + e.which;
 
-    if(keyCode == 191) { // '/' or '?'
+    if(keyCode === 191) { // '/' or '?'
       $('.keyhint').show();
-    } else if(keyCode == 27) { // ESC
+    } else if(keyCode === 27) { // ESC
       $('.keyhint').hide();
     } else {
       $('.soundItem[data-keycode="' + keyCode + '"]').click();
@@ -94,7 +94,7 @@ function init()
   socket.on("version", function(version) {
   	console.log("> version: " + version);
 	console.log("client version: " + client_version);
-	if(client_version != undefined && version != client_version) {
+	if(client_version !== undefined && version !== client_version) {
 		location.reload();
 	}
 	client_version = version;

--- a/webroot/soundbread.js
+++ b/webroot/soundbread.js
@@ -1,7 +1,36 @@
+function soundLoaded(event) {
+  // Sound is loaded, show button
+  var div = document.getElementById(event.id);
+  // do stuff when loaded
+}
+
+function stop() {
+  if (preload != null) {
+    preload.close();
+  }
+  createjs.Sound.stop();
+}
+
+function play(id) {
+  //Play the sound: play (src, interrupt, delay, offset, loop, volume, pan)
+  console.log('play: ' + id);
+  var instance = createjs.Sound.play(id);
+  if (instance == null || instance.playState == createjs.Sound.PLAY_FAILED) {
+    console.log('Play failed');
+    return;
+  }
+
+  $('#' + id).addClass('active');
+  instance.addEventListener("complete", function (instance) {
+    $('#' + id).removeClass("active");
+  });
+}
+
 function init()
 {
   var preload;
-  var client_version = undefined;
+  var client_version;
+  var keyCode;  
 
   var maxcredits = 5;
   $('#credits').attr('aria-valuemax', maxcredits);
@@ -90,32 +119,4 @@ function init()
     console.log("Error: " + data);
   });
 
-}
-
-function soundLoaded(event) {
-  // Sound is loaded, show button
-  var div = document.getElementById(event.id);
-  // do stuff when loaded
-}
-
-function stop() {
-  if (preload != null) {
-    preload.close();
-  }
-  createjs.Sound.stop();
-}
-
-function play(id) {
-  //Play the sound: play (src, interrupt, delay, offset, loop, volume, pan)
-  console.log('play: ' + id);
-  var instance = createjs.Sound.play(id);
-  if (instance == null || instance.playState == createjs.Sound.PLAY_FAILED) {
-    console.log('Play failed');
-    return;
-  }
-
-  $('#' + id).addClass('active');
-  instance.addEventListener("complete", function (instance) {
-    $('#' + id).removeClass("active");
-  });
 }


### PR DESCRIPTION
In order to make sure that the javascript is syntactically correct before pushing it to github and then heroku, I have added a pre-commit hook that uses jshint to check the javascript before committing. Jshint is in npm so no additional OS dependencies are needed.

NPM dependencies for jshint and the pre-commit module have been added as devDependencies, so these will be automatically installed when doing npm install. For production deployment you can use the --production flag, or set the NODE_ENV variable to "production", then npm will not install these two devDependencies. It might be a good idea to see if the heroku deployment hooks deploy with this option.

Of course, once you start actually checking code all kinds of things pop up so I've changed some of the code to be a bit more strict, changes are mostly regarding equality operators so === instead of == and !== instead of !=, going forward you will need to code using these equality operators. I opted to do this instead of disabling the checks. If so desired, the checks for this can be disabled by setting "eqeqeq" to false in .jshintrc, and a rather obscure option "-W041" to false that is the same as eqeqeq but deals specifically with comparisons with null.
Another somewhat major-looking change is moving the function declarations around in server.js, so that the variables and functions are actually defined before being used in init()

Jquery and soundjs have been excluded from checks via the .jshintignore file.
